### PR TITLE
using '/>' rather '>' to generate valid html fragment for non-closed tag...

### DIFF
--- a/Code/HTMLSerialization.m
+++ b/Code/HTMLSerialization.m
@@ -153,11 +153,13 @@ static void RecursiveDescriptionHelper(HTMLNode *self, NSMutableString *string, 
         [fragment appendFormat:@" %@=\"%@\"", name, escapedValue];
     }];
 
-    [fragment appendString:@">"];
     
     if (StringIsEqualToAnyOf(self.tagName, @"area", @"base", @"basefont", @"bgsound", @"br", @"col", @"embed", @"frame", @"hr", @"img", @"input", @"keygen", @"link", @"menuitem", @"meta", @"param", @"source", @"track", @"wbr")) {
+        [fragment appendString:@" />"];
         return fragment;
     }
+    
+    [fragment appendString:@">"];
     
     if (StringIsEqualToAnyOf(self.tagName, @"pre", @"textarea", @"listing")) {
         if ([self.children.firstObject isKindOfClass:[HTMLTextNode class]]) {

--- a/Tests/HTMLSerializerTests.m
+++ b/Tests/HTMLSerializerTests.m
@@ -17,7 +17,7 @@
 - (void)testBareElement
 {
     HTMLElement *node = [[HTMLElement alloc] initWithTagName:@"br" attributes:nil];
-    XCTAssertEqualObjects(node.serializedFragment, @"<br>");
+    XCTAssertEqualObjects(node.serializedFragment, @"<br />");
 }
 
 // From html5lib's serializers/core.test


### PR DESCRIPTION
I think it would generate `<img />` rather `<img>`.