### PR TITLE
Update HtmlParser.m to handle the crashing

### DIFF
--- a/Code/HTMLParser.m
+++ b/Code/HTMLParser.m
@@ -3209,6 +3209,12 @@ HTMLParser * ParserWithDataAndContentType(NSData *data, NSString *contentType)
 {
     HTMLStringEncoding initialEncoding = DeterminedStringEncodingForData(data, contentType);
     NSString *initialString = [[NSString alloc] initWithData:data encoding:initialEncoding.encoding];
+    
+    if(!initialString){
+        HTMLStringEncoding newInitialEncoding = DeterminedStringEncodingForData(data, @"text/html; charset=ASCII");
+        initialString = [[NSString alloc] initWithData:data encoding:newInitialEncoding.encoding];
+    }
+    
     HTMLParser *initialParser = [[HTMLParser alloc] initWithString:initialString encoding:initialEncoding context:nil];
     __block HTMLParser *parser = initialParser;
     initialParser.changeEncoding = ^(HTMLStringEncoding newEncoding) {


### PR DESCRIPTION
When there are several strange character, using the contentType to encode can return the initialString to be nil and thus crash all the parsing process since then(For my case is UTF8). So add the hard-coded ASCII contentType to handle the crash.

For example, try 
http://www.macrumors.com/2015/07/16/apple-standardized-e-sim-cards/