### PR TITLE
Export public headers when building static library

### DIFF
--- a/HTMLReader.xcodeproj/project.pbxproj
+++ b/HTMLReader.xcodeproj/project.pbxproj
@@ -106,6 +106,18 @@
 		1CD5251A18DC8845003F46A3 /* HTMLReader.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1C88293B18369DD70051653C /* HTMLReader.framework */; };
 		1CE12D091A12120E00FFA8C0 /* HTMLSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 1CC6691818D604BC00BDF7B8 /* HTMLSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1CF4584217CC83DD000F64B5 /* HTMLSerializerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1CF4584117CC83DD000F64B5 /* HTMLSerializerTests.m */; };
+		66BD10441BBF7C6A00B9346B /* HTMLDocument.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 1C25D3A6177BB78600F7C10D /* HTMLDocument.h */; };
+		66BD10451BBF7C6A00B9346B /* HTMLDocumentType.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 1CA5C21918D7479C00147FE7 /* HTMLDocumentType.h */; };
+		66BD10461BBF7C6A00B9346B /* HTMLElement.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 1CA5C20F18D7457400147FE7 /* HTMLElement.h */; };
+		66BD10471BBF7C7400B9346B /* HTMLNamespace.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 1CD5250218DB5F1B003F46A3 /* HTMLNamespace.h */; };
+		66BD10481BBF7C7400B9346B /* HTMLNode.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 1CACE9E21783A92F00754A8F /* HTMLNode.h */; };
+		66BD10491BBF7C8700B9346B /* HTMLQuirksMode.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 1CD5250018DB5DCD003F46A3 /* HTMLQuirksMode.h */; };
+		66BD104A1BBF7C8700B9346B /* HTMLReader.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 1CB61D2417BB671A00EE9653 /* HTMLReader.h */; };
+		66BD104B1BBF7C8700B9346B /* HTMLSelector.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 83C4518717BAFE3500C144DF /* HTMLSelector.h */; };
+		66BD104C1BBF7C9C00B9346B /* HTMLSerialization.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 1CD524F818D74CFF003F46A3 /* HTMLSerialization.h */; };
+		66BD104D1BBF7C9C00B9346B /* HTMLSupport.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 1CC6691818D604BC00BDF7B8 /* HTMLSupport.h */; };
+		66BD104E1BBF7CA500B9346B /* NSString+HTMLEntities.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 1C8E10531919F1560010007B /* NSString+HTMLEntities.h */; };
+		66BD104F1BBF7CAC00B9346B /* HTMLComment.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 1CA5C21418D746D600147FE7 /* HTMLComment.h */; };
 		83C4518917BAFE3500C144DF /* HTMLSelector.m in Sources */ = {isa = PBXBuildFile; fileRef = 83C4518817BAFE3500C144DF /* HTMLSelector.m */; };
 		83C4518D17BB1FA500C144DF /* HTMLSelectorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 83C4518C17BB1FA400C144DF /* HTMLSelectorTests.m */; };
 /* End PBXBuildFile section */
@@ -134,6 +146,18 @@
 			dstPath = "include/${PRODUCT_NAME}";
 			dstSubfolderSpec = 16;
 			files = (
+				66BD104F1BBF7CAC00B9346B /* HTMLComment.h in CopyFiles */,
+				66BD104E1BBF7CA500B9346B /* NSString+HTMLEntities.h in CopyFiles */,
+				66BD104C1BBF7C9C00B9346B /* HTMLSerialization.h in CopyFiles */,
+				66BD104D1BBF7C9C00B9346B /* HTMLSupport.h in CopyFiles */,
+				66BD10491BBF7C8700B9346B /* HTMLQuirksMode.h in CopyFiles */,
+				66BD104A1BBF7C8700B9346B /* HTMLReader.h in CopyFiles */,
+				66BD104B1BBF7C8700B9346B /* HTMLSelector.h in CopyFiles */,
+				66BD10471BBF7C7400B9346B /* HTMLNamespace.h in CopyFiles */,
+				66BD10481BBF7C7400B9346B /* HTMLNode.h in CopyFiles */,
+				66BD10441BBF7C6A00B9346B /* HTMLDocument.h in CopyFiles */,
+				66BD10451BBF7C6A00B9346B /* HTMLDocumentType.h in CopyFiles */,
+				66BD10461BBF7C6A00B9346B /* HTMLElement.h in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ You have choices:
 * Add the following line to your [Podfile][CocoaPods]:
    
    `pod "HTMLReader"`
-* Clone this repository (perhaps add it as a submodule), add `HTMLReader.xcodeproj` to your project/workspace, and add `libHTMLReader.a` to your iOS target or `HTMLReader.framework` to your OS X target.
+* Clone this repository (perhaps add it as a submodule), add `HTMLReader.xcodeproj` to your project/workspace, and add `libHTMLReader.a` to your iOS target or `HTMLReader.framework` to your OS X target. Also add `"$(SYMROOT)/include"` to your target's Header Search Paths.
 
 HTMLReader has no dependencies other than Foundation.
 


### PR DESCRIPTION
Headers are inaccessible when using HTMLReader as an xcode subproject and the static library target. Headers are now exported publicly to the built products' directory, and can be added by adding "$(SYMROOT)/include" to a target's Header Search Paths.

The chosen public headers are mirrored from the Framework target.