### PR TITLE
Fixed some bitrot in the Xcode playground.

### DIFF
--- a/HTMLReader.playground/Contents.swift
+++ b/HTMLReader.playground/Contents.swift
@@ -1,17 +1,26 @@
 //: HTMLReader – A WHATWG-compliant HTML parser
-
 import HTMLReader
 import XCPlayground
-XCPSetExecutionShouldContinueIndefinitely()
+
+XCPlaygroundPage.currentPage.needsIndefiniteExecution = true
 
 let homepage = "https://github.com/nolanw/HTMLReader"
-NSURLSession.sharedSession().dataTaskWithURL(NSURL(string: homepage)!) { (data, response, error) in
+NSURLSession.sharedSession().dataTaskWithURL(NSURL(string: homepage)!) {
+    (data, response, error) in
     var contentType: String? = nil
     if let response = response as? NSHTTPURLResponse {
         contentType = response.allHeaderFields["Content-Type"] as? String
     }
-    let home = HTMLDocument(data: data, contentTypeHeader:contentType)
-    let div = home.firstNodeMatchingSelector(".repository-description")
-    let whitespace = NSCharacterSet.whitespaceAndNewlineCharacterSet()
-    println(div.textContent.stringByTrimmingCharactersInSet(whitespace))
+    if let data = data {
+        let home = HTMLDocument(data: data, contentTypeHeader:contentType)
+        if let div = home.firstNodeMatchingSelector(".repository-meta-content") {
+            let whitespace = NSCharacterSet.whitespaceAndNewlineCharacterSet()
+            print(div.textContent.stringByTrimmingCharactersInSet(whitespace))
+        } else {
+            print("Failed to match .repository-meta-content, maybe the HTML changed?")
+        }
+    } else {
+        print("No data received, sorry.")
+    }
+    XCPlaygroundPage.finishExecution(XCPlaygroundPage.currentPage)
 }.resume()

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ NSURLSession *session = [NSURLSession sharedSession];
     }
     HTMLDocument *home = [HTMLDocument documentWithData:data
                                       contentTypeHeader:contentType];
-    HTMLElement *div = [home firstNodeMatchingSelector:@".repository-description"];
+    HTMLElement *div = [home firstNodeMatchingSelector:@".repository-meta-content"];
     NSCharacterSet *whitespace = [NSCharacterSet whitespaceAndNewlineCharacterSet];
     NSLog(@"%@", [div.textContent stringByTrimmingCharactersInSet:whitespace]);
     // => A WHATWG-compliant HTML parser in Objective-C.


### PR DESCRIPTION
Among other things, GitHub have apparently renamed `.repository-description` to `.repository-meta-content`, which broke the sample code.