### PR TITLE
Removed an assert that made the test suite fail without html5lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ There are C libraries such as [Gumbo][] or [Hubbub][], but you need to shuffle d
 
 ## Does it work?
 
-HTMLReader continually runs [html5lib][html5lib-tests]'s tokenization and tree construction tests, ignoring the tests for `<template>` (which HTMLReader does not implement).
+HTMLReader continually runs [html5lib][html5lib-tests]'s tokenization and tree construction tests, ignoring the tests for `<template>` (which HTMLReader does not implement). Note that you need to check out the `Tests/html5lib` Git submodule in order to actually run these tests.
 
 HTMLReader is continually tested on iOS versions 7.0, 7.1, and 8.1, as well as OS X versions 10.9 and 10.10. It should work on down to iOS 5 and OS X 10.7 but no automated testing is done.
 

--- a/Tests/HTMLEncodingTests.m
+++ b/Tests/HTMLEncodingTests.m
@@ -153,7 +153,9 @@ static NSArray * TestFileURLs(void)
                                                         includingPropertiesForKeys:nil
                                                                            options:NSDirectoryEnumerationSkipsHiddenFiles
                                                                              error:&error];
-    NSCAssert(candidates, @"possible error listing test directory: %@", error);
+    if (candidates == nil) {
+        NSLog(@"Cannot find the HTML5 tests, do you have the submodule (%@) checked out?", html5libTestPath());
+    }
     
     // Skipping test-yahoo-jp.dat because I can't be bothered to figure out how it's encoded.
     NSPredicate *predicate = [NSPredicate predicateWithFormat:@"pathExtension = 'dat' && lastPathComponent != 'test-yahoo-jp.dat'"];


### PR DESCRIPTION
Fixes #51. I have tried to find a way to turn the failing assert into a warning, but didn’t succeed, so I at least added a line in the log saying the submodule wasn’t found.