### PR TITLE
Use https instead of ssh for submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "HTMLReaderTests/html5lib"]
 	path = HTMLReaderTests/html5lib
-	url = git://github.com/html5lib/html5lib-tests.git
+	url = https://github.com/html5lib/html5lib-tests.git


### PR DESCRIPTION
Fix for #92 

Github no longer supports the git:// protocol: https://github.blog/2021-09-01-improving-git-protocol-security-github/